### PR TITLE
chore: update compatibilityDate to 2026-06-30

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,7 +20,7 @@ export default defineNuxtConfig({
     viewTransition: true
   },
 
-  compatibilityDate: '2024-07-11',
+  compatibilityDate: '2026-06-30',
 
   nitro: {
     experimental: {


### PR DESCRIPTION
Updates the Nuxt `compatibilityDate` to today's date (2026-06-30).