### PR TITLE
fix: add a visible focus ring to the logo link

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -82,7 +82,11 @@ defineShortcuts({
       class="border-r-0 py-4 dark:[--ui-bg-elevated:var(--ui-color-neutral-900)]"
     >
       <template #header="{ collapsed }">
-        <NuxtLink v-if="!collapsed" to="/" class="flex items-end gap-0.5">
+        <NuxtLink
+          v-if="!collapsed"
+          to="/"
+          class="flex items-end gap-0.5 outline-primary/25 focus-visible:outline-3 rounded-md"
+        >
           <Logo class="h-8 w-auto shrink-0" />
           <span class="text-xl font-bold text-highlighted">Chat</span>
         </NuxtLink>


### PR DESCRIPTION
The logo link had no focus style of its own, so tabbing to it fell back to the browser default. Adds the same treatment already shipping in `calendar`:

```
outline-primary/25 focus-visible:outline-3 rounded-md
```

No padding here, matching the sidebar variant in `calendar/app/components/AppSidebar.vue`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the sidebar home link with rounded styling.
  - Added visible focus outlines to improve keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->